### PR TITLE
refactor: update zap logger call

### DIFF
--- a/internal/core/crawler/crawler_service.go
+++ b/internal/core/crawler/crawler_service.go
@@ -9,8 +9,6 @@ import (
 	"github.com/hiago-balbino/web-crawler/internal/core/pager"
 	"github.com/hiago-balbino/web-crawler/internal/pkg/logger"
 	"github.com/hiago-balbino/web-crawler/internal/pkg/metrics"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/html"
 )
 
@@ -64,7 +62,7 @@ func (p CrawlerService) Craw(ctx context.Context, uri string, depth uint) ([]str
 	for fetching := uint(1); fetching <= depth; fetching++ {
 		linkAddress := <-ch
 		if linkAddress.err != nil {
-			log.Error("error to get uri node", zap.Field{Type: zapcore.StringType, String: linkAddress.err.Error()})
+			log.Error("error to get uri node", logger.FieldError(linkAddress.err))
 			metrics.LinksErrorCounter.Inc()
 
 			return nil, linkAddress.err
@@ -93,7 +91,7 @@ func (p CrawlerService) Craw(ctx context.Context, uri string, depth uint) ([]str
 	}()
 
 	if err := p.database.Insert(ctx, uri, depth, links); err != nil {
-		log.Error("error inserting data into database", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error inserting data into database", logger.FieldError(err))
 	}
 
 	return links, nil

--- a/internal/core/pager/pager_service.go
+++ b/internal/core/pager/pager_service.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 
 	"github.com/hiago-balbino/web-crawler/internal/pkg/logger"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/html"
 )
 
@@ -27,14 +25,14 @@ func (c PagerService) GetNode(uri string) (*html.Node, error) {
 		}
 	}()
 	if err != nil {
-		log.Error("error to perform get request in provider", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error to perform get request in provider", logger.FieldError(err))
 
 		return nil, err
 	}
 
 	node, err := html.Parse(response.Body)
 	if err != nil {
-		log.Error("error to parse response body to html", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error to parse response body to html", logger.FieldError(err))
 
 		return nil, err
 	}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	core "github.com/hiago-balbino/web-crawler/internal/core/crawler"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"github.com/hiago-balbino/web-crawler/internal/pkg/logger"
 )
 
 type Handler struct {
@@ -20,14 +19,14 @@ func NewHandler(service core.CrawlerUsecase) Handler {
 func (h Handler) getPageCrawled(c *gin.Context) {
 	var crawPageInfo crawPageInfo
 	if err := c.BindQuery(&crawPageInfo); err != nil {
-		log.Error("error binding query params", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error binding query params", logger.FieldError(err))
 		c.HTML(http.StatusBadRequest, "error.html", gin.H{"error": err.Error()})
 
 		return
 	}
 
 	if err := crawPageInfo.validate(); err != nil {
-		log.Error("error validating parameters", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error validating parameters", logger.FieldError(err))
 		c.HTML(http.StatusBadRequest, "error.html", gin.H{"error": err.Error()})
 
 		return
@@ -35,7 +34,7 @@ func (h Handler) getPageCrawled(c *gin.Context) {
 
 	links, err := h.service.Craw(c.Request.Context(), crawPageInfo.URI, crawPageInfo.Depth)
 	if err != nil {
-		log.Error("error crawling page", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error crawling page", logger.FieldError(err))
 		c.HTML(http.StatusInternalServerError, "error.html", gin.H{"error": err.Error()})
 
 		return

--- a/internal/handler/server.go
+++ b/internal/handler/server.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hiago-balbino/web-crawler/internal/repository/storage"
 	"github.com/penglongli/gin-metrics/ginmetrics"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var log = logger.GetLogger()
@@ -41,7 +39,7 @@ func (s Server) Start() {
 	monitor.Use(router)
 
 	if err := router.Run(fmt.Sprintf(":%s", viper.GetString("API_PORT"))); err != nil {
-		log.Fatal("error while server starting", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Fatal("error while server starting", logger.FieldError(err))
 	}
 }
 

--- a/internal/pkg/logger/zap_logger.go
+++ b/internal/pkg/logger/zap_logger.go
@@ -37,6 +37,10 @@ func GetLogger() *zap.Logger {
 	return Logger
 }
 
+func FieldError(err error) zapcore.Field {
+	return zapcore.Field{Type: zapcore.StringType, String: err.Error()}
+}
+
 func getLogLevel() zapcore.Level {
 	logLevel := viper.GetString("LOG_LEVEL")
 

--- a/internal/repository/storage/crawler_mongodb_repository.go
+++ b/internal/repository/storage/crawler_mongodb_repository.go
@@ -10,8 +10,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var log = logger.GetLogger()
@@ -33,7 +31,7 @@ func NewCrawlerMongodbRepository(ctx context.Context) CrawlerMongodbRepository {
 	opts := options.Client().ApplyURI(endpoint)
 	client, err := mongo.Connect(ctx, opts)
 	if err != nil {
-		log.Error("error connecting to mongodb", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error connecting to mongodb", logger.FieldError(err))
 	}
 
 	return CrawlerMongodbRepository{client}
@@ -51,7 +49,7 @@ func (c CrawlerMongodbRepository) Insert(ctx context.Context, uri string, depth 
 	}
 	_, err := c.getCollection().InsertOne(ctx, pageDataInfo)
 	if err != nil {
-		log.Error("error while inserting new data into collection", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error while inserting new data into collection", logger.FieldError(err))
 
 		return err
 	}
@@ -64,7 +62,7 @@ func (c CrawlerMongodbRepository) Find(ctx context.Context, uri string, depth ui
 	pageDataInfo := pageDataInfo{}
 	err := c.getCollection().FindOne(ctx, filter).Decode(&pageDataInfo)
 	if err != nil {
-		log.Error("error while fetching data from collection", zap.Field{Type: zapcore.StringType, String: err.Error()})
+		log.Error("error while fetching data from collection", logger.FieldError(err))
 
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/hiago-balbino/web-crawler/cmd"
 	"github.com/hiago-balbino/web-crawler/internal/pkg/logger"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -11,6 +10,6 @@ func main() {
 	if err != nil {
 		logger.
 			GetLogger().
-			Fatal("error initializing the application", zapcore.Field{Type: zapcore.StringType, String: err.Error()})
+			Fatal("error initializing the application", logger.FieldError(err))
 	}
 }


### PR DESCRIPTION
Create reusable function to `zapcore.Field` and update the entire project to use instead of `zap.Field{Type: zapcore.StringType, String: err.Error()}`